### PR TITLE
Singleton pattern applied to data sources access

### DIFF
--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -2,9 +2,10 @@
 from ..services.location.csbs import CSBSLocationService
 from ..services.location.jhu import JhuLocationService
 from ..services.location.nyt import NYTLocationService
+from ..utils.singleton import Singleton
 
 
-class DataSources:
+class DataSources(Singleton):
     """
     Class to represent the root of the aggregate containing the location services.
     """
@@ -16,8 +17,15 @@ class DataSources:
         "nyt": NYTLocationService(),
     }
 
+    __instance = None
+
     def __init__(self):
         pass
+
+    def get_instance():
+        if DataSources.__instance is None:
+            DataSources.__instance = DataSources()
+        return DataSources.__instance
 
     def get_data_source(self, source):
         """

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -3,19 +3,36 @@ from ..services.location.csbs import CSBSLocationService
 from ..services.location.jhu import JhuLocationService
 from ..services.location.nyt import NYTLocationService
 
-# Mapping of services to data-sources.
-DATA_SOURCES = {
-    "jhu": JhuLocationService(),
-    "csbs": CSBSLocationService(),
-    "nyt": NYTLocationService(),
-}
 
-
-def data_source(source):
+class DataSources:
     """
-    Retrieves the provided data-source service.
-
-    :returns: The service.
-    :rtype: LocationService
+    Class to represent the root of the aggregate containing the location services.
     """
-    return DATA_SOURCES.get(source.lower())
+
+    # Mapping of services to data-sources.
+    __DATA_SOURCES_MAP = {
+        "jhu": JhuLocationService(),
+        "csbs": CSBSLocationService(),
+        "nyt": NYTLocationService(),
+    }
+
+    def __init__(self):
+        pass
+
+    def get_data_source(self, source):
+        """
+        Retrieves the provided data-source service.
+
+        :returns: The service.
+        :rtype: LocationService
+        """
+        return self.__DATA_SOURCES_MAP.get(source.lower())
+
+    def get_data_sources(self):
+        """
+            Retrieves a dict of all data sources.
+
+            :returns: The dictionary of data sources.
+            :rtype: dict
+        """
+        return self.__DATA_SOURCES_MAP

--- a/app/main.py
+++ b/app/main.py
@@ -41,7 +41,7 @@ APP = FastAPI(
     on_shutdown=[teardown_client_session],
 )
 
-DATA_SOURCES = DataSources()
+DATA_SOURCES = DataSources.get_instance()
 
 # #####################
 # Middleware

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ from scout_apm.async_.starlette import ScoutMiddleware
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 from .config import get_settings
-from .data import data_source
+from .data import DataSources
 from .routers import V1, V2
 from .utils.httputils import setup_client_session, teardown_client_session
 
@@ -40,6 +40,8 @@ APP = FastAPI(
     on_startup=[setup_client_session],
     on_shutdown=[teardown_client_session],
 )
+
+DATA_SOURCES = DataSources()
 
 # #####################
 # Middleware
@@ -73,8 +75,8 @@ async def add_datasource(request: Request, call_next):
     """
     Attach the data source to the request.state.
     """
-    # Retrieve the datas ource from query param.
-    source = data_source(request.query_params.get("source", default="jhu"))
+    # Retrieve the data source from query param.
+    source = DATA_SOURCES.get_data_source(request.query_params.get("source", default="jhu"))
 
     # Abort with 404 if source cannot be found.
     if not source:

--- a/app/routers/v2.py
+++ b/app/routers/v2.py
@@ -7,7 +7,7 @@ from ..data import DataSources
 from ..models import LatestResponse, LocationResponse, LocationsResponse
 
 V2 = APIRouter()
-DATA_SOURCES = DataSources()
+DATA_SOURCES = DataSources.get_instance()
 
 
 class Sources(str, enum.Enum):

--- a/app/routers/v2.py
+++ b/app/routers/v2.py
@@ -3,10 +3,11 @@ import enum
 
 from fastapi import APIRouter, HTTPException, Request
 
-from ..data import DATA_SOURCES
+from ..data import DataSources
 from ..models import LatestResponse, LocationResponse, LocationsResponse
 
 V2 = APIRouter()
+DATA_SOURCES = DataSources()
 
 
 class Sources(str, enum.Enum):
@@ -107,4 +108,4 @@ async def sources():
     """
     Retrieves a list of data-sources that are availble to use.
     """
-    return {"sources": list(DATA_SOURCES.keys())}
+    return {"sources": list(DATA_SOURCES.get_data_sources().keys())}

--- a/app/utils/singleton.py
+++ b/app/utils/singleton.py
@@ -1,0 +1,11 @@
+class Singleton(object):
+    def __new__(cls, *args, **kwds):
+        it = cls.__dict__.get("__it__")
+        if it is not None:
+            return it
+        cls.__it__ = it = object.__new__(cls)
+        it.init(*args, **kwds)
+        return it
+
+    def init(self, *args, **kwds):
+        pass


### PR DESCRIPTION
### What does this PR do? 

This PR restructures the code in `app/data/__init__.py` to implement a singleton pattern for a new class, `DataSources`, through which clients can retrieve a list of all data sources or a specific data source. I made these changes by adding this DataSources class in `app/data/__init__.py`, making the data sources dictionary private to that class, and updating references to this dictionary and it's accessor method in both `app/main.py` and `app/routers/v2.py`. I updated the existing accessor method, and added a new one to accommodate code in v2.py which required access to the entire dictionary. 

I then created a new util file, `singleton.py`, which defines a base `Singleton` class that the `DataSources` class inherits from. This base singleton is taken from the [python documentation](https://www.python.org/download/releases/2.2/descrintro/#__new__), which states that the singleton pattern can be implemented in python in this way, by overriding the `__new__` method. Since there is no way to truly make methods private in python, the `DataSources` class still has an `__init__` method, but since it inherits from the singleton base class, it is guaranteed to only ever create a single instance of `DataSources`. I created another method, `get_instance`, which serves as the intended way to access the instance of the `DataSources` class, by only ever returning a reference to a single instance of the class. 


### Why make these changes? 

Since multiple parts of the code (main, routers/v2) all need access to the different location services, it seems intuitive to encapsulate these services into a single class, and then maintain only a single instance of the class, through which the location services can be accessed. And this, of course, can be done through the singleton pattern. Creating a singleton and using it in this way helps maintain the constraint that only one location service will be used at any given time, since it will be impossible for multiple instances of the `DataSources` class to exist, and since the main accessor method of the aggregate root will only return a single location service. 

Additionally, applying the singleton pattern here will help save memory, since instead of multiple instances and multiple location services existing, there will just be one instance of the `DataSources` class, which itself only stores single instances of the location service classes. This also takes the responsibility of managing these multiple instances away from the parts of code that instantiate them, since there will only ever be one instance accessible.  